### PR TITLE
Fix file override

### DIFF
--- a/djangocli/cli/commands/base_helper.py
+++ b/djangocli/cli/commands/base_helper.py
@@ -31,7 +31,9 @@ class BaseHelper(object):
             file.close()
             os.chdir(directory)
         except FileExistsError:
-            if click.prompt(f"Override existing {filename} file?"):
+
+            can_override = click.confirm(f"Override existing {filename} file?")
+            if can_override:
                 with open(filename, 'w') as file:
                     file.write(file_content)
                     file.write('\n')


### PR DESCRIPTION
Addresses #32
Correctly asks for confirmation before overriding files and proceeds with user-specified option.